### PR TITLE
pipeline() is actually called execPipeline().

### DIFF
--- a/node-netpbm.js
+++ b/node-netpbm.js
@@ -177,7 +177,7 @@ module.exports.convert = function(fileIn, fileOut, options, callback)
     function execPipeline() {
       if (active >= limit) {
         setTimeout(function() {
-            pipeline();
+            execPipeline();
             return;
           },
           100);


### PR DESCRIPTION
This was causing aborts when processing many files.
