### PR TITLE
Prevent `node-netpbm` from crashing on invalid JPEGs

### DIFF
--- a/node-netpbm.js
+++ b/node-netpbm.js
@@ -120,6 +120,12 @@ module.exports.convert = function(fileIn, fileOut, options, callback)
           callback(err + ': ' + stderr);
           return;
         }
+
+        if (!stdout) {
+          callback("No netpbm output");
+          return;
+        }
+
         var lines = stdout.split(/[\r\n]+/);
         // PAM files are different, sigh
         if (lines[1].match(/^WIDTH (\d+)/) && lines[2].match(/^HEIGHT (\d+)/))

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "P'unk Avenue LLC <tom@punkave.com> (http://punkave.com/)",
   "name": "netpbm",
   "description": "Convert and scale JPEG, GIF and PNG images without running out of memory, even when the images are very large. Fully asynchronous.",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "license": "MIT",
   "engines": {
     "node": ">=0.8"


### PR DESCRIPTION
The `jpegtopnm` command on invalid JPEGs can sometimes output `''`, i.e. silent error. Prevent this from crashing the script.

Please publish the changes to npm too. :)
