### PR TITLE
Declare variables so they don't end up globals

### DIFF
--- a/node-netpbm.js
+++ b/node-netpbm.js
@@ -158,6 +158,7 @@ module.exports.convert = function(fileIn, fileOut, options, callback)
       return;
     }
 
+    var scaler, fitter;
     if (options.alpha) {
       scaler = 'pamscale ';
       fitter = '-xyfit ';


### PR DESCRIPTION
`scaler` and `fitter` variables were never declared.
